### PR TITLE
Class visitors

### DIFF
--- a/packages/stack-tools-node/test/errors.js
+++ b/packages/stack-tools-node/test/errors.js
@@ -10,15 +10,20 @@ const {
   makeTestErrors,
 } = require('./fixtures/errors.js');
 
+const ErrorChain = (errors) => ({ type: 'ErrorChain', errors });
+
 test('cleans a causal chain of errors', (t) => {
-  t.deepEqual(cleanErrors(parseErrors(makeTestErrors())), [
-    {
-      ...testErrorNode,
-      frames: [fileFooFrame],
-    },
-    {
-      ...testCauseNode,
-      frames: [fileBarFrame],
-    },
-  ]);
+  t.deepEqual(
+    cleanErrors(parseErrors(makeTestErrors())),
+    ErrorChain([
+      {
+        ...testErrorNode,
+        frames: [fileFooFrame],
+      },
+      {
+        ...testCauseNode,
+        frames: [fileBarFrame],
+      },
+    ]),
+  );
 });

--- a/packages/stack-tools-v8/lib/error.js
+++ b/packages/stack-tools-v8/lib/error.js
@@ -6,7 +6,7 @@ const { parseUnambiguous } = require('./internal/nearley/util.js');
 const CompiledErrorGrammar = require('./internal/nearley/error.js');
 const { parseHeader } = require('./internal/header.js');
 const { parseFrame, isInternalFrame } = require('./frame.js');
-const { visit, isNode } = require('./visit.js');
+const { printNode, isNode } = require('./visit.js');
 
 const ErrorsGrammar = Grammar.fromCompiled(CompiledErrorGrammar);
 const ErrorGrammar = Grammar.fromCompiled({ ...CompiledErrorGrammar, ParserStart: 'Error' });
@@ -49,10 +49,16 @@ function parseError(error, options = {}) {
 
 function printError(error, options = {}) {
   const { strict, frames } = options;
-  if (isError(error) && strict) {
-    return basePrintError(error, { frames });
+  if (isError(error)) {
+    if (strict) {
+      return basePrintError(error, { frames });
+    } else {
+      return printNode(parseError(error, options));
+    }
+  } else if (isNode(error, 'ErrorChain')) {
+    return printNode(error, options);
   } else {
-    return visit(parseError(error, options));
+    throw new TypeError('error argument to printError must be an Error, or parseError(error)');
   }
 }
 

--- a/packages/stack-tools-v8/lib/frame.js
+++ b/packages/stack-tools-v8/lib/frame.js
@@ -3,7 +3,7 @@ const { Grammar } = require('nearley');
 const { parseFrameStrict } = require('./internal/frame-strict.js');
 const { parse } = require('./internal/nearley/util.js');
 const CompiledFrameGrammar = require('./internal/nearley/frame.js');
-const { visit } = require('./visit.js');
+const { printNode } = require('./visit.js');
 
 const FrameGrammar = Grammar.fromCompiled(CompiledFrameGrammar);
 
@@ -88,7 +88,7 @@ function parseFrame(str) {
 }
 
 function printFrame(frame) {
-  return visit(frame);
+  return printNode(frame);
 }
 
 function isInternalFrame(frame) {

--- a/packages/stack-tools-v8/lib/internal/nearley/error.ne
+++ b/packages/stack-tools-v8/lib/internal/nearley/error.ne
@@ -10,6 +10,10 @@ const lexer = moo.compile({
   MessageLine: /^.+$/,
 });
 
+const buildErrorChain = (errors) => {
+  return { type: 'ErrorChain', errors };
+};
+
 const buildError = (header, frames) => {
   return { type: 'Error', header, frames };
 };
@@ -20,9 +24,9 @@ const buildError = (header, frames) => {
 
 ErrorStack ->
   CompleteError (NL CompleteError):*
-  {% (d) => [d[0], ...d[1].map((d) => d[1])] %}
+  {% (d) => buildErrorChain([d[0], ...d[1].map((d) => d[1])]) %}
   | Header
-  {% (d) => [buildError(d[0])] %}
+  {% (d) => buildErrorChain([buildError(d[0])]) %}
 
 Error ->
   CompleteError {% id %}

--- a/packages/stack-tools-v8/lib/visit.mjs
+++ b/packages/stack-tools-v8/lib/visit.mjs
@@ -1,7 +1,7 @@
 import exports from './visit.js';
 
 export const nodeTypes = exports.nodeTypes;
-export const defaultVisitors = exports.defaultVisitors;
+export const Visitor = exports.Visitor;
+export const PrintVisitor = exports.PrintVisitor;
+export const printNode = exports.printNode;
 export const isNode = exports.isNode;
-export const makeVisit = exports.makeVisit;
-export const visit = exports.visit;

--- a/packages/stack-tools/README.md
+++ b/packages/stack-tools/README.md
@@ -62,7 +62,7 @@ Utilities that work with stacks from any environment are in the `stack-tools` mo
 The following methods are provided:
 
 - `replaceMessage(error, message)` replaces `error.message` with `message` and also updates the text of `error.stack`. `message` may also be a `message => newMessage` callback.
-- `getErrorChain(error)` returns an array of causally chained errors, e.g. `[error, error.cause, error.cause.cause]`,
+- `getErrors(error)` returns an array of causally chained errors, e.g. `[error, error.cause, error.cause.cause]`,
 - `parseError(error, ?options)` returns an error AST node. For more info see the [AST docs](https://github.com/stack-tools-js/stack-tools/packages/stack-tools/lib/ast.d.ts).
 - `parseErrors(errors, ?options)` returns an array of error AST nodes.
 - `printError(error, ?options)` returns `` `${printHeader(errror)}\n${error.stack}` ``

--- a/packages/stack-tools/lib/ast.d.ts
+++ b/packages/stack-tools/lib/ast.d.ts
@@ -21,3 +21,8 @@ export type ErrorNode = {
   message: ErrorMessageNode | undefined;
   frames: Array<FrameNode> | undefined;
 };
+
+export type ErrorChainNode = {
+  type: 'ErrorChain';
+  errors: Array<ErrorNode>;
+};

--- a/packages/stack-tools/lib/error.js
+++ b/packages/stack-tools/lib/error.js
@@ -1,6 +1,6 @@
 const isError = require('iserror');
 
-const { isNode, visit } = require('./visit.js');
+const { isNode, printNode } = require('./visit.js');
 
 // Stolen from escape-string-regexp © sindresorhus
 // It was easier to copy the code than transpile to cjs inside node_modules
@@ -80,10 +80,16 @@ function replaceMessage(error, message) {
 
 function printError(error, options = {}) {
   const { frames = true } = options;
-  if (isError(error) && error.stack && frames) {
-    return error.stack;
+  if (isError(error)) {
+    if (error.stack && frames) {
+      return error.stack;
+    } else {
+      return printNode(parseError(error, options));
+    }
+  } else if (isNode(error, 'Error')) {
+    return printNode(error, options);
   } else {
-    return visit(parseError(error, options));
+    throw new Error('error argument to printError must be an Error or parseError(error)');
   }
 }
 

--- a/packages/stack-tools/lib/errors.mjs
+++ b/packages/stack-tools/lib/errors.mjs
@@ -1,5 +1,5 @@
 import exports from './errors.js';
 
-export const getErrorChain = exports.getErrorChain;
+export const getErrors = exports.getErrors;
 export const parseErrors = exports.parseErrors;
 export const printErrors = exports.printErrors;

--- a/packages/stack-tools/lib/index.d.ts
+++ b/packages/stack-tools/lib/index.d.ts
@@ -1,18 +1,18 @@
-import type { ErrorNode } from './ast';
+import type { ErrorNode, ErrorChainNode } from './ast';
 
 export * from './ast';
 
-export function getErrorChain(error: Error): Array<Error>;
-
-export function parseError(error: Error | ErrorNode): ErrorNode;
+export function getErrors(error: Error): Array<Error>;
 
 export function replaceMessage(
   error: Error,
   message: string | ((message: string) => string),
 ): Error;
 
+export function parseError(error: Error | ErrorNode): ErrorNode;
+
 export function printError(error: Error | ErrorNode): string;
 
-export function parseErrors(error: Error | Array<ErrorNode | Error>): Array<ErrorNode>;
+export function parseErrors(error: Error | ErrorChainNode): ErrorChainNode;
 
-export function printErrors(error: Error | Array<ErrorNode>): string;
+export function printErrors(error: Error | ErrorChainNode): string;

--- a/packages/stack-tools/lib/index.js
+++ b/packages/stack-tools/lib/index.js
@@ -2,4 +2,4 @@ const error = require('./error.js');
 const errors = require('./errors.js');
 const visit = require('./visit.js');
 
-module.exports = Object.assign({}, error, errors, visit);
+module.exports = { ...error, ...errors, ...visit };

--- a/packages/stack-tools/lib/visit.mjs
+++ b/packages/stack-tools/lib/visit.mjs
@@ -1,7 +1,7 @@
 import exports from './visit.js';
 
 export const nodeTypes = exports.nodeTypes;
-export const defaultVisitors = exports.defaultVisitors;
+export const Visitor = exports.Visitor;
+export const PrintVisitor = exports.PrintVisitor;
+export const printNode = exports.printNode;
 export const isNode = exports.isNode;
-export const makeVisit = exports.makeVisit;
-export const visit = exports.visit;

--- a/packages/stack-tools/test/errors.js
+++ b/packages/stack-tools/test/errors.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 
-const { getErrorChain, parseErrors, printErrors } = require('stack-tools');
+const { getErrors, parseErrors, printErrors } = require('stack-tools');
 const {
   testCauseHeader,
   testCauseStack,
@@ -13,11 +13,14 @@ const {
 } = require('../../../test/fixtures/errors.js');
 
 test('can get errors', (t) => {
-  t.deepEqual(getErrorChain(makeTestErrors()), [makeTestErrors(), makeTestCause()]);
+  t.deepEqual(getErrors(makeTestErrors()), [makeTestErrors(), makeTestCause()]);
 });
 
 test('can parse a chain of error', (t) => {
-  t.deepEqual(parseErrors(makeTestErrors()), [testErrorNode, testCauseNode]);
+  t.deepEqual(parseErrors(makeTestErrors()), {
+    type: 'ErrorChain',
+    errors: [testErrorNode, testCauseNode],
+  });
 
   // We can't parse this because we have no idea what the syntax of stack frames is
   t.throws(() => parseErrors('Error: Message'));


### PR DESCRIPTION
The idea here is that a chalk package should be implemented as an extension of some base set of visitors. Classes are the best existing paradigm for extending, and many of their semantics will be helpful to us: prototype chain traversal gives us defaults, and the `super` keyword gives us access when we override an implementation from a base class.

For consistency we also now treat a chain of errors as a real AST node.